### PR TITLE
gasolina grafico alteracao de cor do grafico

### DIFF
--- a/gasolina.py
+++ b/gasolina.py
@@ -4,8 +4,8 @@ import seaborn as sns
 gasolina_df = pd.read_csv('gasolina.csv')
 # gasolina_df.head() 
 with sns.axes_style('whitegrid'):
-  grafico_gasolina = sns.lineplot(data=gasolina_df, x='dia', y='venda')
-  grafico_gasolina.set(title='Preço médio da gasolina em SP em Julho de 2021',
+  grafico_gasolina = sns.lineplot(data=gasolina_df, x='dia', y='venda', palette='pastel')
+  grafico_gasolina.set(title='Preço médio da gasolina no mês de Julho de 2021 em SP',
   xlabel='Dias',
   ylabel='Preço médio (R$)')
 


### PR DESCRIPTION
### Descrição
Criação de branch develop para alterar cor e legenda do gráfico gasolina criado na main branch. 

### Solução

- Foi adicionado o parâmetro palette='pastel' ao método .sns.lineplot() para alterar a cor do gráfico gasolina. 

- Foi alterado a legenda do gráfico gasolina. 